### PR TITLE
hash based input checking

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -478,6 +478,7 @@ for name in ['build',
              'debug_flags',
              'depfile_parser',
              'deps_log',
+             'hash_log',
              'disk_interface',
              'edit_distance',
              'eval_env',
@@ -504,6 +505,7 @@ else:
     objs += cxx('subprocess-posix')
 if platform.is_aix():
     objs += cc('getopt')
+objs += cc('PMurHash')
 if platform.is_msvc():
     ninja_lib = n.build(built('ninja.lib'), 'ar', objs)
 else:
@@ -542,6 +544,7 @@ for name in ['build_log_test',
              'clean_test',
              'depfile_parser_test',
              'deps_log_test',
+             'hash_log_test',
              'disk_interface_test',
              'edit_distance_test',
              'graph_test',

--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -670,6 +670,38 @@ While a task in the `console` pool is running, Ninja's regular output (such
 as progress status and output from concurrent tasks) is buffered until
 it completes.
 
+[[ref_hash]]
+Hash Input
+~~~~~~~~~~
+
+_Available since Ninja ???_
+
+In some workloads the modification timestamps of source files are updated
+without changing their contents.  One example of this is interacting with
+version control software, e.g. rebasing or switching branches.  Also, some
+editors write files button is pressed even if no actual changes were made.
+This can lead to time consuming, unnecessary rebuilds - especially when it
+happens for header files that are dependencies for many targets in a big
+project.  Ninja can remedy these situations with hash based input checking.
+Enabling this feature for a rule will create a new log file in which hashes of
+each edge's inputs will be stored.  When the edge is later considered for
+rebuilding an updated timestamp of an input file will be ignored if the hash of
+its input matches the recorded one.
+
+The option can be enabled for any rule:
+
+----
+rule cc
+  ...
+  hash_input = 1
+  ...
+----
+
+Be aware that hashing has linear growing costs with input size. Hence it
+might be too expensive for linker inputs (object files, etc). But it is
+valuable for any kind of source files.
+
+
 Ninja file reference
 --------------------
 
@@ -810,6 +842,9 @@ keys.
   rules are treated specially in two ways: firstly, they will not be
   rebuilt if the command line changes; and secondly, they are not
   cleaned by default.
+
+`hash_input`:: _(Available since Ninja ???)_ if present, inputs are hashed
+  and considered dirty for a rebuild only if their content changed
 
 `in`:: the space-separated list of files provided as inputs to the build line
   referencing this `rule`, shell-quoted if it appears in commands.  (`$in` is

--- a/misc/ninja.vim
+++ b/misc/ninja.vim
@@ -40,7 +40,7 @@ syn match ninjaKeyword "^subninja\>"
 " manifest_parser.cc, ParseRule()
 syn region ninjaRule start="^rule" end="^\ze\S" contains=ALL transparent
 syn keyword ninjaRuleCommand contained command deps depfile description generator
-                                     \ pool restat rspfile rspfile_content
+                                     \ pool restat rspfile rspfile_content hash_input
 
 syn region ninjaPool start="^pool" end="^\ze\S" contains=ALL transparent
 syn keyword ninjaPoolCommand contained depth

--- a/misc/ninja_syntax.py
+++ b/misc/ninja_syntax.py
@@ -39,7 +39,7 @@ class Writer(object):
 
     def rule(self, name, command, description=None, depfile=None,
              generator=False, pool=None, restat=False, rspfile=None,
-             rspfile_content=None, deps=None):
+             rspfile_content=None, deps=None, hash_input=False):
         self._line('rule %s' % name)
         self.variable('command', command, indent=1)
         if description:
@@ -58,6 +58,8 @@ class Writer(object):
             self.variable('rspfile_content', rspfile_content, indent=1)
         if deps:
             self.variable('deps', deps, indent=1)
+        if hash_input:
+            self.variable('hash_input', '1', indent=1)
 
     def build(self, outputs, rule, inputs=None, implicit=None, order_only=None,
               variables=None):

--- a/src/PMurHash.c
+++ b/src/PMurHash.c
@@ -1,0 +1,317 @@
+/*-----------------------------------------------------------------------------
+ * MurmurHash3 was written by Austin Appleby, and is placed in the public
+ * domain.
+ *
+ * This implementation was written by Shane Day, and is also public domain.
+ *
+ * This is a portable ANSI C implementation of MurmurHash3_x86_32 (Murmur3A)
+ * with support for progressive processing.
+ */
+
+/*-----------------------------------------------------------------------------
+ 
+If you want to understand the MurmurHash algorithm you would be much better
+off reading the original source. Just point your browser at:
+http://code.google.com/p/smhasher/source/browse/trunk/MurmurHash3.cpp
+
+
+What this version provides?
+
+1. Progressive data feeding. Useful when the entire payload to be hashed
+does not fit in memory or when the data is streamed through the application.
+Also useful when hashing a number of strings with a common prefix. A partial
+hash of a prefix string can be generated and reused for each suffix string.
+
+2. Portability. Plain old C so that it should compile on any old compiler.
+Both CPU endian and access-alignment neutral, but avoiding inefficient code
+when possible depending on CPU capabilities.
+
+3. Drop in. I personally like nice self contained public domain code, making it
+easy to pilfer without loads of refactoring to work properly in the existing
+application code & makefile structure and mucking around with licence files.
+Just copy PMurHash.h and PMurHash.c and you're ready to go.
+
+
+How does it work?
+
+We can only process entire 32 bit chunks of input, except for the very end
+that may be shorter. So along with the partial hash we need to give back to
+the caller a carry containing up to 3 bytes that we were unable to process.
+This carry also needs to record the number of bytes the carry holds. I use
+the low 2 bits as a count (0..3) and the carry bytes are shifted into the
+high byte in stream order.
+
+To handle endianess I simply use a macro that reads a uint32_t and define
+that macro to be a direct read on little endian machines, a read and swap
+on big endian machines, or a byte-by-byte read if the endianess is unknown.
+
+-----------------------------------------------------------------------------*/
+
+
+#include "PMurHash.h"
+
+/* I used ugly type names in the header to avoid potential conflicts with
+ * application or system typedefs & defines. Since I'm not including any more
+ * headers below here I can rename these so that the code reads like C99 */
+#undef uint32_t
+#define uint32_t MH_UINT32
+#undef uint8_t
+#define uint8_t  MH_UINT8
+
+/* MSVC warnings we choose to ignore */
+#if defined(_MSC_VER)
+  #pragma warning(disable: 4127) /* conditional expression is constant */
+#endif
+
+/*-----------------------------------------------------------------------------
+ * Endianess, misalignment capabilities and util macros
+ *
+ * The following 3 macros are defined in this section. The other macros defined
+ * are only needed to help derive these 3.
+ *
+ * READ_UINT32(x)   Read a little endian unsigned 32-bit int
+ * UNALIGNED_SAFE   Defined if READ_UINT32 works on non-word boundaries
+ * ROTL32(x,r)      Rotate x left by r bits
+ */
+
+/* Convention is to define __BYTE_ORDER == to one of these values */
+#if !defined(__BIG_ENDIAN)
+  #define __BIG_ENDIAN 4321
+#endif
+#if !defined(__LITTLE_ENDIAN)
+  #define __LITTLE_ENDIAN 1234
+#endif
+
+/* I386 */
+#if defined(_M_IX86) || defined(__i386__) || defined(__i386) || defined(i386)
+  #define __BYTE_ORDER __LITTLE_ENDIAN
+  #define UNALIGNED_SAFE
+#endif
+
+/* gcc 'may' define __LITTLE_ENDIAN__ or __BIG_ENDIAN__ to 1 (Note the trailing __),
+ * or even _LITTLE_ENDIAN or _BIG_ENDIAN (Note the single _ prefix) */
+#if !defined(__BYTE_ORDER)
+  #if defined(__LITTLE_ENDIAN__) && __LITTLE_ENDIAN__==1 || defined(_LITTLE_ENDIAN) && _LITTLE_ENDIAN==1
+    #define __BYTE_ORDER __LITTLE_ENDIAN
+  #elif defined(__BIG_ENDIAN__) && __BIG_ENDIAN__==1 || defined(_BIG_ENDIAN) && _BIG_ENDIAN==1
+    #define __BYTE_ORDER __BIG_ENDIAN
+  #endif
+#endif
+
+/* gcc (usually) defines xEL/EB macros for ARM and MIPS endianess */
+#if !defined(__BYTE_ORDER)
+  #if defined(__ARMEL__) || defined(__MIPSEL__)
+    #define __BYTE_ORDER __LITTLE_ENDIAN
+  #endif
+  #if defined(__ARMEB__) || defined(__MIPSEB__)
+    #define __BYTE_ORDER __BIG_ENDIAN
+  #endif
+#endif
+
+/* Now find best way we can to READ_UINT32 */
+#if __BYTE_ORDER==__LITTLE_ENDIAN
+  /* CPU endian matches murmurhash algorithm, so read 32-bit word directly */
+  #define READ_UINT32(ptr)   (*((uint32_t*)(ptr)))
+#elif __BYTE_ORDER==__BIG_ENDIAN
+  /* TODO: Add additional cases below where a compiler provided bswap32 is available */
+  #if defined(__GNUC__) && (__GNUC__>4 || (__GNUC__==4 && __GNUC_MINOR__>=3))
+    #define READ_UINT32(ptr)   (__builtin_bswap32(*((uint32_t*)(ptr))))
+  #else
+    /* Without a known fast bswap32 we're just as well off doing this */
+    #define READ_UINT32(ptr)   (ptr[0]|ptr[1]<<8|ptr[2]<<16|ptr[3]<<24)
+    #define UNALIGNED_SAFE
+  #endif
+#else
+  /* Unknown endianess so last resort is to read individual bytes */
+  #define READ_UINT32(ptr)   (ptr[0]|ptr[1]<<8|ptr[2]<<16|ptr[3]<<24)
+
+  /* Since we're not doing word-reads we can skip the messing about with realignment */
+  #define UNALIGNED_SAFE
+#endif
+
+/* Find best way to ROTL32 */
+#if defined(_MSC_VER)
+  #include <stdlib.h>  /* Microsoft put _rotl declaration in here */
+  #define ROTL32(x,r)  _rotl(x,r)
+#else
+  /* gcc recognises this code and generates a rotate instruction for CPUs with one */
+  #define ROTL32(x,r)  (((uint32_t)x << r) | ((uint32_t)x >> (32 - r)))
+#endif
+
+
+/*-----------------------------------------------------------------------------
+ * Core murmurhash algorithm macros */
+
+#define C1  (0xcc9e2d51)
+#define C2  (0x1b873593)
+
+/* This is the main processing body of the algorithm. It operates
+ * on each full 32-bits of input. */
+#define DOBLOCK(h1, k1) do{ \
+        k1 *= C1; \
+        k1 = ROTL32(k1,15); \
+        k1 *= C2; \
+        \
+        h1 ^= k1; \
+        h1 = ROTL32(h1,13); \
+        h1 = h1*5+0xe6546b64; \
+    }while(0)
+
+
+/* Append unaligned bytes to carry, forcing hash churn if we have 4 bytes */
+/* cnt=bytes to process, h1=name of h1 var, c=carry, n=bytes in c, ptr/len=payload */
+#define DOBYTES(cnt, h1, c, n, ptr, len) do{ \
+    int _i = cnt; \
+    while(_i--) { \
+        c = c>>8 | *ptr++<<24; \
+        n++; len--; \
+        if(n==4) { \
+            DOBLOCK(h1, c); \
+            n = 0; \
+        } \
+    } }while(0)
+
+/*---------------------------------------------------------------------------*/
+
+/* Main hashing function. Initialise carry to 0 and h1 to 0 or an initial seed
+ * if wanted. Both ph1 and pcarry are required arguments. */
+void PMurHash32_Process(uint32_t *ph1, uint32_t *pcarry, const void *key, int len)
+{
+  uint32_t h1 = *ph1;
+  uint32_t c = *pcarry;
+
+  const uint8_t *ptr = (uint8_t*)key;
+  const uint8_t *end;
+
+  /* Extract carry count from low 2 bits of c value */
+  int n = c & 3;
+
+#if defined(UNALIGNED_SAFE)
+  /* This CPU handles unaligned word access */
+
+  /* Consume any carry bytes */
+  int i = (4-n) & 3;
+  if(i && i <= len) {
+    DOBYTES(i, h1, c, n, ptr, len);
+  }
+
+  /* Process 32-bit chunks */
+  end = ptr + len/4*4;
+  for( ; ptr < end ; ptr+=4) {
+    uint32_t k1 = READ_UINT32(ptr);
+    DOBLOCK(h1, k1);
+  }
+
+#else /*UNALIGNED_SAFE*/
+  /* This CPU does not handle unaligned word access */
+
+  /* Consume enough so that the next data byte is word aligned */
+  int i = -(long)ptr & 3;
+  if(i && i <= len) {
+      DOBYTES(i, h1, c, n, ptr, len);
+  }
+
+  /* We're now aligned. Process in aligned blocks. Specialise for each possible carry count */
+  end = ptr + len/4*4;
+  switch(n) { /* how many bytes in c */
+  case 0: /* c=[----]  w=[3210]  b=[3210]=w            c'=[----] */
+    for( ; ptr < end ; ptr+=4) {
+      uint32_t k1 = READ_UINT32(ptr);
+      DOBLOCK(h1, k1);
+    }
+    break;
+  case 1: /* c=[0---]  w=[4321]  b=[3210]=c>>24|w<<8   c'=[4---] */
+    for( ; ptr < end ; ptr+=4) {
+      uint32_t k1 = c>>24;
+      c = READ_UINT32(ptr);
+      k1 |= c<<8;
+      DOBLOCK(h1, k1);
+    }
+    break;
+  case 2: /* c=[10--]  w=[5432]  b=[3210]=c>>16|w<<16  c'=[54--] */
+    for( ; ptr < end ; ptr+=4) {
+      uint32_t k1 = c>>16;
+      c = READ_UINT32(ptr);
+      k1 |= c<<16;
+      DOBLOCK(h1, k1);
+    }
+    break;
+  case 3: /* c=[210-]  w=[6543]  b=[3210]=c>>8|w<<24   c'=[654-] */
+    for( ; ptr < end ; ptr+=4) {
+      uint32_t k1 = c>>8;
+      c = READ_UINT32(ptr);
+      k1 |= c<<24;
+      DOBLOCK(h1, k1);
+    }
+  }
+#endif /*UNALIGNED_SAFE*/
+
+  /* Advance over whole 32-bit chunks, possibly leaving 1..3 bytes */
+  len -= len/4*4;
+
+  /* Append any remaining bytes into carry */
+  DOBYTES(len, h1, c, n, ptr, len);
+
+  /* Copy out new running hash and carry */
+  *ph1 = h1;
+  *pcarry = (c & ~0xff) | n;
+} 
+
+/*---------------------------------------------------------------------------*/
+
+/* Finalize a hash. To match the original Murmur3A the total_length must be provided */
+uint32_t PMurHash32_Result(uint32_t h, uint32_t carry, uint32_t total_length)
+{
+  uint32_t k1;
+  int n = carry & 3;
+  if(n) {
+    k1 = carry >> (4-n)*8;
+    k1 *= C1; k1 = ROTL32(k1,15); k1 *= C2; h ^= k1;
+  }
+  h ^= total_length;
+
+  /* fmix */
+  h ^= h >> 16;
+  h *= 0x85ebca6b;
+  h ^= h >> 13;
+  h *= 0xc2b2ae35;
+  h ^= h >> 16;
+
+  return h;
+}
+
+/*---------------------------------------------------------------------------*/
+
+/* Murmur3A compatable all-at-once */
+uint32_t PMurHash32(uint32_t seed, const void *key, int len)
+{
+  uint32_t h1=seed, carry=0;
+  PMurHash32_Process(&h1, &carry, key, len);
+  return PMurHash32_Result(h1, carry, len);
+}
+
+/*---------------------------------------------------------------------------*/
+
+/* Provide an API suitable for smhasher */
+void PMurHash32_test(const void *key, int len, uint32_t seed, void *out)
+{
+  uint32_t h1=seed, carry=0;
+  const uint8_t *ptr = (uint8_t*)key;
+  const uint8_t *end = ptr + len;
+
+#if 0 /* Exercise the progressive processing */
+  while(ptr < end) {
+    //const uint8_t *mid = ptr + rand()%(end-ptr)+1;
+    const uint8_t *mid = ptr + (rand()&0xF);
+    mid = mid<end?mid:end;
+    PMurHash32_Process(&h1, &carry, ptr, mid-ptr);
+    ptr = mid;
+  }
+#else
+  PMurHash32_Process(&h1, &carry, ptr, (int)(end-ptr));
+#endif
+  h1 = PMurHash32_Result(h1, carry, len);
+  *(uint32_t*)out = h1;
+}
+
+/*---------------------------------------------------------------------------*/

--- a/src/PMurHash.h
+++ b/src/PMurHash.h
@@ -1,0 +1,64 @@
+/*-----------------------------------------------------------------------------
+ * MurmurHash3 was written by Austin Appleby, and is placed in the public
+ * domain.
+ *
+ * This implementation was written by Shane Day, and is also public domain.
+ *
+ * This is a portable ANSI C implementation of MurmurHash3_x86_32 (Murmur3A)
+ * with support for progressive processing.
+ */
+
+/* ------------------------------------------------------------------------- */
+/* Determine what native type to use for uint32_t */
+
+/* We can't use the name 'uint32_t' here because it will conflict with
+ * any version provided by the system headers or application. */
+
+/* First look for special cases */
+#if defined(_MSC_VER)
+  #define MH_UINT32 unsigned long
+#endif
+
+/* If the compiler says it's C99 then take its word for it */
+#if !defined(MH_UINT32) && ( \
+     defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L )
+  #include <stdint.h>
+  #define MH_UINT32 uint32_t
+#endif
+
+/* Otherwise try testing against max value macros from limit.h */
+#if !defined(MH_UINT32)
+  #include  <limits.h>
+  #if   (USHRT_MAX == 0xffffffffUL)
+    #define MH_UINT32 unsigned short
+  #elif (UINT_MAX == 0xffffffffUL)
+    #define MH_UINT32 unsigned int
+  #elif (ULONG_MAX == 0xffffffffUL)
+    #define MH_UINT32 unsigned long
+  #endif
+#endif
+
+#if !defined(MH_UINT32)
+  #error Unable to determine type name for unsigned 32-bit int
+#endif
+
+/* I'm yet to work on a platform where 'unsigned char' is not 8 bits */
+#define MH_UINT8  unsigned char
+
+
+/* ------------------------------------------------------------------------- */
+/* Prototypes */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void PMurHash32_Process(MH_UINT32 *ph1, MH_UINT32 *pcarry, const void *key, int len);
+MH_UINT32 PMurHash32_Result(MH_UINT32 h1, MH_UINT32 carry, MH_UINT32 total_length);
+MH_UINT32 PMurHash32(MH_UINT32 seed, const void *key, int len);
+
+void PMurHash32_test(const void *key, int len, MH_UINT32 seed, void *out);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/build.h
+++ b/src/build.h
@@ -33,6 +33,7 @@ struct BuildLog;
 struct BuildStatus;
 struct DiskInterface;
 struct Edge;
+struct HashLog;
 struct Node;
 struct State;
 
@@ -140,7 +141,7 @@ struct BuildConfig {
 struct Builder {
   Builder(State* state, const BuildConfig& config,
           BuildLog* build_log, DepsLog* deps_log,
-          DiskInterface* disk_interface);
+          HashLog* hash_log, DiskInterface* disk_interface);
   ~Builder();
 
   /// Clean up after interrupted commands by deleting output files.

--- a/src/build_test.cc
+++ b/src/build_test.cc
@@ -468,7 +468,7 @@ struct FakeCommandRunner : public CommandRunner {
 
 struct BuildTest : public StateTestWithBuiltinRules, public BuildLogUser {
   BuildTest() : config_(MakeConfig()), command_runner_(&fs_),
-                builder_(&state_, config_, NULL, NULL, &fs_),
+                builder_(&state_, config_, NULL, NULL, NULL, &fs_),
                 status_(config_) {
   }
 
@@ -541,7 +541,7 @@ void BuildTest::RebuildTarget(const string& target, const char* manifest,
     pdeps_log = &deps_log;
   }
 
-  Builder builder(pstate, config_, pbuild_log, pdeps_log, &fs_);
+  Builder builder(pstate, config_, pbuild_log, pdeps_log, NULL, &fs_);
   EXPECT_TRUE(builder.AddTarget(target, &err));
 
   command_runner_.commands_ran_.clear();
@@ -1699,7 +1699,7 @@ TEST_F(BuildWithDepsLogTest, Straightforward) {
     ASSERT_TRUE(deps_log.OpenForWrite("ninja_deps", &err));
     ASSERT_EQ("", err);
 
-    Builder builder(&state, config_, NULL, &deps_log, &fs_);
+    Builder builder(&state, config_, NULL, &deps_log, NULL, &fs_);
     builder.command_runner_.reset(&command_runner_);
     EXPECT_TRUE(builder.AddTarget("out", &err));
     ASSERT_EQ("", err);
@@ -1729,7 +1729,7 @@ TEST_F(BuildWithDepsLogTest, Straightforward) {
     ASSERT_TRUE(deps_log.Load("ninja_deps", &state, &err));
     ASSERT_TRUE(deps_log.OpenForWrite("ninja_deps", &err));
 
-    Builder builder(&state, config_, NULL, &deps_log, &fs_);
+    Builder builder(&state, config_, NULL, &deps_log, NULL, &fs_);
     builder.command_runner_.reset(&command_runner_);
     command_runner_.commands_ran_.clear();
     EXPECT_TRUE(builder.AddTarget("out", &err));
@@ -1770,7 +1770,7 @@ TEST_F(BuildWithDepsLogTest, ObsoleteDeps) {
     ASSERT_TRUE(deps_log.OpenForWrite("ninja_deps", &err));
     ASSERT_EQ("", err);
 
-    Builder builder(&state, config_, NULL, &deps_log, &fs_);
+    Builder builder(&state, config_, NULL, &deps_log, NULL, &fs_);
     builder.command_runner_.reset(&command_runner_);
     EXPECT_TRUE(builder.AddTarget("out", &err));
     ASSERT_EQ("", err);
@@ -1799,7 +1799,7 @@ TEST_F(BuildWithDepsLogTest, ObsoleteDeps) {
     ASSERT_TRUE(deps_log.Load("ninja_deps", &state, &err));
     ASSERT_TRUE(deps_log.OpenForWrite("ninja_deps", &err));
 
-    Builder builder(&state, config_, NULL, &deps_log, &fs_);
+    Builder builder(&state, config_, NULL, &deps_log, NULL, &fs_);
     builder.command_runner_.reset(&command_runner_);
     command_runner_.commands_ran_.clear();
     EXPECT_TRUE(builder.AddTarget("out", &err));
@@ -1835,7 +1835,7 @@ TEST_F(BuildWithDepsLogTest, DepsIgnoredInDryRun) {
 
   // The deps log is NULL in dry runs.
   config_.dry_run = true;
-  Builder builder(&state, config_, NULL, NULL, &fs_);
+  Builder builder(&state, config_, NULL, NULL, NULL, &fs_);
   builder.command_runner_.reset(&command_runner_);
   command_runner_.commands_ran_.clear();
 
@@ -1893,7 +1893,7 @@ TEST_F(BuildWithDepsLogTest, RestatDepfileDependencyDepsLog) {
     ASSERT_TRUE(deps_log.OpenForWrite("ninja_deps", &err));
     ASSERT_EQ("", err);
 
-    Builder builder(&state, config_, NULL, &deps_log, &fs_);
+    Builder builder(&state, config_, NULL, &deps_log, NULL, &fs_);
     builder.command_runner_.reset(&command_runner_);
     EXPECT_TRUE(builder.AddTarget("out", &err));
     ASSERT_EQ("", err);
@@ -1919,7 +1919,7 @@ TEST_F(BuildWithDepsLogTest, RestatDepfileDependencyDepsLog) {
     ASSERT_TRUE(deps_log.Load("ninja_deps", &state, &err));
     ASSERT_TRUE(deps_log.OpenForWrite("ninja_deps", &err));
 
-    Builder builder(&state, config_, NULL, &deps_log, &fs_);
+    Builder builder(&state, config_, NULL, &deps_log, NULL, &fs_);
     builder.command_runner_.reset(&command_runner_);
     command_runner_.commands_ran_.clear();
     EXPECT_TRUE(builder.AddTarget("out", &err));
@@ -1952,7 +1952,7 @@ TEST_F(BuildWithDepsLogTest, DepFileOKDepsLog) {
     ASSERT_TRUE(deps_log.OpenForWrite("ninja_deps", &err));
     ASSERT_EQ("", err);
 
-    Builder builder(&state, config_, NULL, &deps_log, &fs_);
+    Builder builder(&state, config_, NULL, &deps_log, NULL, &fs_);
     builder.command_runner_.reset(&command_runner_);
     EXPECT_TRUE(builder.AddTarget("fo o.o", &err));
     ASSERT_EQ("", err);
@@ -1973,7 +1973,7 @@ TEST_F(BuildWithDepsLogTest, DepFileOKDepsLog) {
     ASSERT_TRUE(deps_log.OpenForWrite("ninja_deps", &err));
     ASSERT_EQ("", err);
 
-    Builder builder(&state, config_, NULL, &deps_log, &fs_);
+    Builder builder(&state, config_, NULL, &deps_log, NULL, &fs_);
     builder.command_runner_.reset(&command_runner_);
 
     Edge* edge = state.edges_.back();

--- a/src/disk_interface.cc
+++ b/src/disk_interface.cc
@@ -30,6 +30,8 @@
 
 #include "util.h"
 
+#include "PMurHash.h"
+
 namespace {
 
 string DirName(const string& path) {
@@ -237,6 +239,37 @@ FileReader::Status RealDiskInterface::ReadFile(const string& path,
   case -ENOENT: return NotFound;
   default:      return OtherError;
   }
+}
+
+FileReader::Status RealDiskInterface::HashFile(const string& path,
+                                               Hash* hash,
+                                               string* err) {
+  FILE* f = fopen(path.c_str(), "rb");
+  if (!f) {
+    err->assign(strerror(errno));
+    if (errno == ENOENT)
+      return NotFound;
+    else
+      return OtherError;
+  }
+
+  char buf[64 << 10];
+  MH_UINT32 h1 = 0;
+  MH_UINT32 carry = 0;
+  size_t total_len = 0;
+  size_t len;
+  while ((len = fread(buf, 1, sizeof(buf), f)) > 0) {
+    PMurHash32_Process(&h1, &carry, buf, len);
+    total_len += len;
+  }
+  if (ferror(f)) {
+    err->assign(strerror(errno));  // XXX errno?
+    fclose(f);
+    return OtherError;
+  }
+  *hash = PMurHash32_Result(h1, carry, total_len);
+  fclose(f);
+  return Okay;
 }
 
 int RealDiskInterface::RemoveFile(const string& path) {

--- a/src/disk_interface.h
+++ b/src/disk_interface.h
@@ -39,11 +39,21 @@ struct FileReader {
                           string* err) = 0;
 };
 
+/// Interface for hashing files from disk.
+struct FileHasher {
+  typedef unsigned Hash;
+
+  /// Read file and store hash.  On success, return Okay.
+  /// On error, return another Status and fill |err|.
+  virtual FileReader::Status HashFile(const string& path, Hash *hash,
+                                      string* err) = 0;
+};
+
 /// Interface for accessing the disk.
 ///
 /// Abstract so it can be mocked out for tests.  The real implementation
 /// is RealDiskInterface.
-struct DiskInterface: public FileReader {
+struct DiskInterface: public FileReader, public FileHasher {
   /// stat() a file, returning the mtime, or 0 if missing and -1 on
   /// other errors.
   virtual TimeStamp Stat(const string& path, string* err) const = 0;
@@ -79,6 +89,7 @@ struct RealDiskInterface : public DiskInterface {
   virtual bool MakeDir(const string& path);
   virtual bool WriteFile(const string& path, const string& contents);
   virtual Status ReadFile(const string& path, string* contents, string* err);
+  virtual Status HashFile(const string& path, Hash *hash, string* err);
   virtual int RemoveFile(const string& path);
 
   /// Whether stat information can be cached.  Only has an effect on Windows.

--- a/src/disk_interface_test.cc
+++ b/src/disk_interface_test.cc
@@ -19,6 +19,7 @@
 #include <windows.h>
 #endif
 
+#include "PMurHash.h"
 #include "disk_interface.h"
 #include "graph.h"
 #include "test.h"
@@ -200,9 +201,25 @@ TEST_F(DiskInterfaceTest, RemoveFile) {
   EXPECT_EQ(1, disk_.RemoveFile("does not exist"));
 }
 
+TEST_F(DiskInterfaceTest, HashFile) {
+  const char* kFileName  = "file-to-hash";
+  const char kTestCont[] = "test-content";
+  DiskInterface::Hash hash = 42;
+  string err;
+
+  ASSERT_EQ(DiskInterface::NotFound, disk_.HashFile(kFileName, &hash, &err));
+  ASSERT_FALSE(err.empty());
+  ASSERT_EQ(42, hash);
+
+  err.clear();
+  ASSERT_TRUE(disk_.WriteFile(kFileName, kTestCont));
+  ASSERT_EQ(DiskInterface::Okay, disk_.HashFile(kFileName, &hash, &err));
+  ASSERT_EQ(PMurHash32(0, kTestCont, sizeof(kTestCont) - 1), hash);
+}
+
 struct StatTest : public StateTestWithBuiltinRules,
                   public DiskInterface {
-  StatTest() : scan_(&state_, NULL, NULL, this) {}
+  StatTest() : scan_(&state_, NULL, NULL, NULL, this) {}
 
   // DiskInterface implementation.
   virtual TimeStamp Stat(const string& path, string* err) const;
@@ -221,6 +238,10 @@ struct StatTest : public StateTestWithBuiltinRules,
   virtual int RemoveFile(const string& path) {
     assert(false);
     return 0;
+  }
+  virtual Status HashFile(const string& path, Hash* hash, string* err) {
+    assert(false);
+    return NotFound;
   }
 
   DependencyScan scan_;

--- a/src/eval_env.cc
+++ b/src/eval_env.cc
@@ -72,7 +72,8 @@ bool Rule::IsReservedBinding(const string& var) {
       var == "restat" ||
       var == "rspfile" ||
       var == "rspfile_content" ||
-      var == "msvc_deps_prefix";
+      var == "msvc_deps_prefix" ||
+      var == "hash_input";
 }
 
 const map<string, const Rule*>& BindingEnv::GetRules() const {

--- a/src/graph.h
+++ b/src/graph.h
@@ -20,6 +20,7 @@
 using namespace std;
 
 #include "eval_env.h"
+#include "hash_log.h"
 #include "timestamp.h"
 
 struct BuildLog;
@@ -240,10 +241,11 @@ struct ImplicitDepLoader {
 /// and updating the dirty/outputs_ready state of all the nodes and edges.
 struct DependencyScan {
   DependencyScan(State* state, BuildLog* build_log, DepsLog* deps_log,
-                 DiskInterface* disk_interface)
+                 HashLog* hash_log, DiskInterface* disk_interface)
       : build_log_(build_log),
         disk_interface_(disk_interface),
-        dep_loader_(state, deps_log, disk_interface) {}
+        dep_loader_(state, deps_log, disk_interface),
+        hash_log_(hash_log) {}
 
   /// Examine inputs, outputs, and command lines to judge whether an edge
   /// needs to be re-run, and update outputs_ready_ and each outputs' |dirty_|
@@ -267,6 +269,10 @@ struct DependencyScan {
     return dep_loader_.deps_log();
   }
 
+  HashLog* hash_log() {
+    return hash_log_;
+  }
+
  private:
   /// Recompute whether a given single output should be marked dirty.
   /// Returns true if so.
@@ -276,6 +282,7 @@ struct DependencyScan {
   BuildLog* build_log_;
   DiskInterface* disk_interface_;
   ImplicitDepLoader dep_loader_;
+  HashLog *hash_log_;
 };
 
 #endif  // NINJA_GRAPH_H_

--- a/src/graph_test.cc
+++ b/src/graph_test.cc
@@ -18,7 +18,7 @@
 #include "test.h"
 
 struct GraphTest : public StateTestWithBuiltinRules {
-  GraphTest() : scan_(&state_, NULL, NULL, &fs_) {}
+  GraphTest() : scan_(&state_, NULL, NULL, NULL, &fs_) {}
 
   VirtualFileSystem fs_;
   DependencyScan scan_;

--- a/src/hash_log.cc
+++ b/src/hash_log.cc
@@ -1,0 +1,681 @@
+// Copyright 2014 Matthias Maennich (matthias@maennich.net).
+//           2016 SAP SE
+// All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "hash_log.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+#include "disk_interface.h"
+#include "graph.h"
+#include "state.h"
+#include "hash_map.h"
+#include "metrics.h"
+
+/// The file banner in the persisted hash log.
+static const char kFileSignature[] = "# ninjahash\n";
+static const int kCurrentVersion = 5;
+static const unsigned kMaxRecordSize = (1 << 19) - 1;
+
+// TODO:  Do not hash files greater than a certain size (16kB?).
+// TODO:  Store file size and do not compare hashes if size is different.
+// TODO:  Command line argument, do not load hash log.
+// TODO:  clang-format
+
+bool HashLog::IdHashRecord::operator==(const IdHashRecord &other) const {
+  return id_ == other.id_ && mtime_ == other.mtime_ && value_ == other.value_;
+}
+
+bool HashLog::IdHashRecord::operator<(const IdHashRecord &other) const {
+  return id_ < other.id_;
+}
+bool HashLog::IdHashRecord::operator<(int id) const {
+    return id_ < id;
+}
+
+HashLog::HashLog(FileHasher *hasher)
+  : file_(NULL), hasher_(hasher), needs_recompaction_(false)
+{}
+
+HashLog::~HashLog() {
+  Close();
+}
+
+void HashLog::Close() {
+  if (file_)
+    fclose(file_);
+  file_ = NULL;
+}
+
+bool HashLog::Load(const std::string &path, State *state, std::string* err) {
+  METRIC_RECORD(".ninja_hashes load");
+  char buf[kMaxRecordSize + 1];
+  FILE* f = fopen(path.c_str(), "rb");
+  if (!f) {
+    if (errno == ENOENT)
+      return true;
+    err->assign(strerror(errno));
+    return false;
+  }
+
+  bool valid_header = true;
+  int version = 0;
+  if (!fgets(buf, sizeof(buf), f) || fread(&version, 4, 1, f) < 1)
+    valid_header = false;
+  if (!valid_header || strcmp(buf, kFileSignature) != 0 ||
+      version != kCurrentVersion) {
+    if (version > 0 && version < kCurrentVersion)
+      *err = "hash log version change; rebuilding";
+    else
+      *err = "bad hash log signature or version; starting over";
+    fclose(f);
+    unlink(path.c_str());
+    // Don't report this as a failure.  An empty hash log just means
+    // that we might rebuild stuff we do not really need to.
+    return true;
+  }
+
+  long offset;
+  bool read_failed = false;
+  size_t total_record_count = 0;
+
+  for (;;) {
+    offset = ftell(f);
+
+    unsigned size;
+    if (fread(&size, 4, 1, f) < 1) {
+      if (!feof(f))
+        read_failed = true;
+      break;
+    }
+    bool is_hash = (size >> 31) != 0;
+    size = size & 0x7FFFFFFF;
+
+    if (fread(buf, size, 1, f) < 1 || size > kMaxRecordSize) {
+      read_failed = true;
+      break;
+    }
+
+    if (is_hash) {
+      int* hash_data = reinterpret_cast<int*>(buf);
+      int id = hash_data[0];
+      hash_data += 1;
+      int max_valid_id = ids_.size() - 1;
+
+      if (id > max_valid_id) {
+        read_failed = true;
+        break;
+      }
+
+      int int_count = (size / 4) - 1;
+      if (int_count % 3 != 0) {
+        read_failed = true;
+        break;
+      }
+      int hash_count = int_count / 3;
+
+      if (hash_count == 0) {
+        read_failed = true;
+        break;
+      }
+
+      NodeRecord *record = GetOrCreateRecord(id);
+
+      ++total_record_count;
+
+      Inputs &inputs = record->inputs_;
+      inputs.resize(hash_count);
+
+      for (int i = 0; i < hash_count; ++i) {
+        IdHashRecord &input = inputs[i];
+
+        input.id_ = hash_data[0];
+        input.mtime_ = hash_data[1];
+        input.value_ = hash_data[2];
+        hash_data += 3;
+
+        if (input.id_ > max_valid_id) {
+          read_failed = true;
+          break;
+        }
+
+        // Inputs must be sorted by id.
+        if (i > 0 && input.id_ < inputs[i - 1].id_) {
+          read_failed = true;
+          break;
+        }
+
+        // Update the cache for this entry if the mtime is newer.
+        HashRecord *hash = GetOrCreateRecord(id);
+
+        if (input.mtime_ > hash->mtime_)
+          hash->value_ = input.value_;
+      }
+    } else {
+      int path_size = size - 4;
+      if (buf[path_size - 1] == '\0') --path_size;
+      if (buf[path_size - 1] == '\0') --path_size;
+      if (buf[path_size - 1] == '\0') --path_size;
+      StringPiece subpath(buf, path_size);
+      Node* node = state->GetNode(subpath, 0);
+      unsigned checksum = *reinterpret_cast<unsigned*>(buf + size - 4);
+      int expected_id = ~checksum;
+      int id = ids_.size();
+
+      if (expected_id != id) {
+        read_failed = true;
+        break;
+      }
+
+      ids_[node] = id;
+    }
+  }
+
+  if (read_failed) {
+    // An error occurred while loading; try to recover by truncating the
+    // file to the last fully-read record.
+    if (ferror(f)) {
+      *err = strerror(ferror(f));
+    } else {
+      *err = "premature end of file";
+    }
+    fclose(f);
+
+    if (!Truncate(path, offset, err))
+      return false;
+
+    // The truncate succeeded; we'll just report the load error as a
+    // warning because the build can proceed.
+    *err += "; recovering";
+    return true;
+  }
+
+  fclose(f);
+
+  // Rebuild the log if there are too many dead records.
+  size_t kMinCompactionCount = 1000;
+  size_t kCompactionRatio = 3;
+  if (total_record_count > kMinCompactionCount &&
+      total_record_count > hashes_.size() * kCompactionRatio) {
+    needs_recompaction_ = true;
+  }
+
+  return true;
+}
+
+bool HashLog::OpenForWrite(const std::string &path, std::string* err) {
+  if (needs_recompaction_) {
+    if (!Recompact(path, err))
+      return false;
+  }
+
+  file_ = fopen(path.c_str(), "ab");
+  if (!file_) {
+    *err = strerror(errno);
+    return false;
+  }
+  // Set the buffer size to this and flush the file buffer after every record
+  // to make sure records aren't written partially.
+  setvbuf(file_, NULL, _IOFBF, kMaxRecordSize + 1);
+  SetCloseOnExec(fileno(file_));
+
+  // Opening a file in append mode doesn't set the file pointer to the file's
+  // end on Windows. Do that explicitly.
+  fseek(file_, 0, SEEK_END);
+
+  if (ftell(file_) == 0) {
+    if (fwrite(kFileSignature, sizeof(kFileSignature) - 1, 1, file_) < 1) {
+      *err = strerror(errno);
+      return false;
+    }
+    if (fwrite(&kCurrentVersion, 4, 1, file_) < 1) {
+      *err = strerror(errno);
+      return false;
+    }
+  }
+  if (fflush(file_) != 0) {
+    *err = strerror(errno);
+    return false;
+  }
+  return true;
+}
+
+bool HashLog::Recompact(const std::string &path, std::string* err) {
+  Close();
+  string temp_path = path + ".recompact";
+
+  // OpenForWrite() opens for append.  Make sure it's not appending to a
+  // left-over file from a previous recompaction attempt that crashed somehow.
+  unlink(temp_path.c_str());
+
+  HashLog new_log(NULL);
+  if (!new_log.OpenForWrite(temp_path, err))
+    return false;
+
+  typedef set<IdHashRecord> OrderedInputs;
+
+  // Iterate over current outputs.
+  for (Ids::const_iterator i = ids_.begin(); i != ids_.end(); ++i) {
+    Edge *edge = i->first->in_edge();
+
+    // Skip nodes that do not use hashes.
+    if (!edge || !edge->GetBindingBool("hash_input"))
+      continue;
+
+    // Skip over nodes that aren't outputs.
+    NodeRecord *record = GetRecord(i->second);
+
+    if (!record || record->inputs_.empty())
+      continue;
+
+    OrderedInputs temp_inputs;
+
+    // Extract known hashes for current inputs of recorded outputs.
+    for (vector<Node*>::const_iterator j = edge->inputs_.begin();
+        j != edge->inputs_.end() - edge->order_only_deps_; ++j) {
+      // Get current hash.
+      IdHashRecord *old_input = GetInputHash(record, *j);
+
+      // Might be a new input.
+      if (!old_input)
+        continue;
+
+      // Cornstruct new record from old one.
+      IdHashRecord new_input(*old_input);
+      new_input.id_ = new_log.GetOrCreateId(*j, err);
+
+      if (new_input.id_ == -1)
+        return false;
+
+      temp_inputs.insert(new_input);
+
+      // Also update the last input hash.
+      HashRecord *hash = new_log.GetOrCreateRecord(new_input.id_);
+
+      if (new_input.mtime_ > hash->mtime_)
+        hash->value_ = new_input.value_;
+    }
+
+    Inputs new_inputs(temp_inputs.begin(), temp_inputs.end());
+
+    if (!new_log.RecordHashes(i->first, new_inputs, err))
+      return false;
+  }
+
+  // new_log now has minimal ids_ and hashes_ so steal its data.
+  ids_.swap(new_log.ids_);
+  hashes_.swap(new_log.hashes_);
+
+  if (unlink(path.c_str()) < 0) {
+    *err = strerror(errno);
+    return false;
+  }
+
+  if (rename(temp_path.c_str(), path.c_str()) < 0) {
+    *err = strerror(errno);
+    return false;
+  }
+
+  return true;
+}
+
+bool HashLog::HashesAreClean(Node *output, Edge* edge, std::string* err) {
+  METRIC_RECORD("checking hashes");
+
+  // Find the record for this output.
+  NodeRecord *record = GetRecord(output);
+
+  // Never seen this node.
+  if (!record)
+    return false;
+
+  bool is_clean = true;
+  bool should_rewrite = false;
+
+  // N.B. it may happen that there are less inputs than were recorded
+  // previously.  This case can be ignored because it can only be reached if
+  // the changed set of inputs didn't change the command.
+
+  // Look at all inputs and check if they have been seen before with the same
+  // hash.
+  for (vector<Node*>::const_iterator i = edge->inputs_.begin();
+      i != edge->inputs_.end() - edge->order_only_deps_; ++i) {
+    // Input does not exist or was not stat()ed.
+    if (!(*i)->exists() || !(*i)->status_known()) {
+      is_clean = false;
+      break;
+    }
+
+    // Get the recorded hash.
+    IdHashRecord *recorded_hash = GetInputHash(record, *i);
+
+    // Never seen this node as an input for this output.
+    if (!recorded_hash) {
+      is_clean = false;
+      break;
+    }
+
+    // mtime matches, assume it's clean.
+    if ((*i)->mtime() == recorded_hash->mtime_)
+      continue;
+
+    // Get the current hash.
+    HashRecord *hash = ComputeHash(*i, recorded_hash->id_, err);
+
+    // Hashing failed.
+    if (!hash)
+      return false;
+
+    // Hash is different.
+    if (hash->value_ != recorded_hash->value_) {
+      is_clean = false;
+      break;
+    }
+
+    // Hash is the same.  Continue checking updated the recorded mtime and
+    // remember to rewrite the record later.
+    recorded_hash->mtime_ = hash->mtime_;
+    should_rewrite = true;
+  }
+
+  // At least one input was clean but had to be rehashed because of a different
+  // mtime.  If the log is opened for writing rewrite the record so the hashing
+  // can be skipped next time.
+  if (should_rewrite && file_)
+    if (!WriteEntry(GetId(output), record, err))
+      return false;
+
+  return is_clean;
+}
+
+HashLog::IdHashRecord* HashLog::GetInputHash(NodeRecord *record, Node *input) const {
+  int id = GetId(input);
+
+  if (id == -1)
+    return NULL;
+
+  // Do a binary search to find the input record for this id.
+  Inputs::iterator start = record->inputs_.begin();
+  Inputs::iterator end = record->inputs_.end();
+  Inputs::iterator i = lower_bound(start, end, id);
+
+  if (i != end || i->id_ == id)
+    return &(*i);
+  else
+    return NULL;
+}
+
+HashLog::HashRecord *HashLog::GetInputHash(Node *output, Node *input) const {
+  NodeRecord *record = GetRecord(output);
+
+  if (!record)
+    return NULL;
+  else
+    return GetInputHash(record, input);
+}
+
+HashLog::HashRecord* HashLog::ComputeHash(Node *node, int id, string* err) {
+  HashRecord *hash = GetOrCreateRecord(id);
+
+  if (node->mtime() != hash->mtime_) {
+    if (hasher_->HashFile(node->path(), &hash->value_, err) != DiskInterface::Okay) {
+      *err = "error hashing file: " + *err;
+      return NULL;
+    }
+
+    hash->mtime_ = node->mtime();
+  }
+
+  return hash;
+}
+
+HashLog::HashRecord* HashLog::GetHash(Node *node) const {
+  int id = GetId(node);
+
+  if (id == -1)
+    return NULL;
+
+  int max_hash_id = hashes_.size() - 1;
+
+  if (id > max_hash_id)
+    return NULL;
+
+  return hashes_[id];
+}
+
+HashLog::NodeRecord *HashLog::GetRecord(Node *node) const {
+  int id = GetId(node);
+
+  if (id == -1)
+    return NULL;
+
+  return GetRecord(id);
+}
+
+HashLog::NodeRecord *HashLog::GetRecord(int id) const {
+  int max_id = hashes_.size() - 1;
+
+  if (id > max_id)
+    return NULL;
+
+  return hashes_[id];
+}
+
+size_t HashLog::GetInputCount(Node *node) const {
+  NodeRecord *record = GetRecord(node);
+
+  if (record == NULL)
+    return 0;
+  else
+    return record->inputs_.size();
+}
+
+int HashLog::GetId(Node *node) const {
+  Ids::const_iterator i = ids_.find(node);
+
+  if (i != ids_.end())
+    return i->second;
+  else
+    return -1;
+}
+
+bool HashLog::RecordHashes(Edge* edge, DiskInterface *disk_interface, std::string* err) {
+  METRIC_RECORD("recording hashes");
+
+  // Create an temporary, ordered map of input records.
+  typedef set<IdHashRecord> OrderedInputs;
+  OrderedInputs temp_inputs;
+
+  for (vector<Node*>::const_iterator i = edge->inputs_.begin();
+      i != edge->inputs_.end() - edge->order_only_deps_; ++i) {
+    IdHashRecord input;
+
+    // Get the input id.
+    input.id_ = GetOrCreateId(*i, err);
+
+    if (input.id_ == -1)
+      return false;
+
+    // Make sure the mtime is up to date.
+    if (!(*i)->Stat(disk_interface, err))
+      return false;
+
+    // Get the input hash.
+    HashRecord *hash = ComputeHash(*i, input.id_, err);
+
+    if (!hash)
+      return false;
+
+    input.HashRecord::operator=(*hash);
+    temp_inputs.insert(input);
+  }
+
+  Inputs inputs(temp_inputs.begin(), temp_inputs.end());
+
+  // Record these inputs for all outputs.
+  for (vector<Node*>::const_iterator i = edge->outputs_.begin(); i != edge->outputs_.end(); ++i) {
+    if (!RecordHashes(*i, inputs, err))
+      return false;
+  }
+
+  return true;
+}
+
+int HashLog::GetOrCreateId(Node *node, string* err) {
+  int id = GetId(node);
+
+  // Assign a new id.
+  if (id == -1) {
+    id = ids_.size();
+
+    // Persist the id in the log.
+    if (!WriteId(id, node, err)) {
+      if (err->empty())
+        err->assign(strerror(errno));
+      return false;
+    }
+
+    ids_[node] = id;
+  }
+
+  return id;
+}
+
+bool HashLog::WriteId(int id, Node *node, string* err) {
+  int path_size = node->path().size();
+  int padding = (4 - path_size % 4) % 4;  // Pad path to 4 byte boundary.
+  unsigned size = path_size + padding + 4;
+
+  if (size > kMaxRecordSize) {
+    err->assign(strerror(ERANGE));
+    return false;
+  }
+  if (fwrite(&size, 4, 1, file_) < 1)
+    return false;
+  if (fwrite(node->path().data(), path_size, 1, file_) < 1) {
+    assert(node->path().size() > 0);
+    return false;
+  }
+  if (padding && fwrite("\0\0", padding, 1, file_) < 1)
+    return false;
+  unsigned checksum = ~(unsigned)id;
+  if (fwrite(&checksum, 4, 1, file_) < 1)
+    return false;
+  if (fflush(file_) != 0)
+    return false;
+
+  return true;
+}
+
+HashLog::NodeRecord* HashLog::GetOrCreateRecord(int id) {
+  int max_id = hashes_.size() - 1;
+
+  if (id > max_id)
+    hashes_.resize(id + 1);
+
+  NodeRecord*& record = hashes_[id];
+
+  if (record == NULL)
+    record = new NodeRecord;
+
+  return record;
+}
+
+bool HashLog::RecordHashes(Node *output_node, const Inputs& new_inputs, string* err) {
+  int id = GetOrCreateId(output_node, err);
+
+  if (id == -1)
+    return false;
+
+  NodeRecord *record = GetOrCreateRecord(id);
+  bool need_update = false;
+
+  if (record->inputs_.size() == new_inputs.size())
+    need_update = !equal(record->inputs_.begin(), record->inputs_.end(), new_inputs.begin());
+  else
+    need_update = true;
+
+  if (!need_update)
+    return true;
+
+  record->inputs_ = new_inputs;
+
+  return WriteEntry(id, record, err);
+}
+
+bool HashLog::WriteEntry(int id, NodeRecord *record, string* err) {
+  // Do not store empty sets of inputs.
+  if (record->inputs_.empty())
+    return true;
+
+  // N.B. The record might also have a valid mtime and hash but in that case it
+  // is an input to another output and these values are persisted there.
+
+  // size, output id and (id, mtime, hash) for each input
+  unsigned size = 4 + 4 * 3 * record->inputs_.size();
+
+  if (size > kMaxRecordSize) {
+    err->assign(strerror(ERANGE));
+    return false;
+  }
+
+  size |= 0x80000000;  // Hash record: set high bit.
+
+  if (fwrite(&size, 4, 1, file_) < 1)
+    return false;
+
+  int int_id = id;
+
+  if (fwrite(&int_id, 4, 1, file_) < 1)
+    return false;
+
+  for (Inputs::const_iterator it = record->inputs_.begin(); it != record->inputs_.end(); ++it) {
+    int id = it->id_;
+    if (fwrite(&id, 4, 1, file_) < 1)
+      return false;
+    int timestamp = it->mtime_;
+    if (fwrite(&timestamp, 4, 1, file_) < 1)
+      return false;
+    int hash = it->value_;
+    if (fwrite(&hash, 4, 1, file_) < 1)
+      return false;
+  }
+
+  if (fflush(file_) != 0)
+    return false;
+
+  return true;
+}
+
+vector<Node*> HashLog::GetOutputs() const {
+  vector<Node*> outputs;
+
+  for (Ids::const_iterator i = ids_.begin(); i != ids_.end(); ++i) {
+    NodeRecord *record = GetRecord(i->second);
+
+    if (!record || record->inputs_.empty())
+      continue;
+
+    outputs.push_back(i->first);
+  }
+
+  return outputs;
+}

--- a/src/hash_log.h
+++ b/src/hash_log.h
@@ -1,0 +1,179 @@
+// Copyright 2014 Matthias Maennich (matthias@maennich.net)
+//           2016 SAP SE
+// All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NINJA_HASH_LOG_H_
+#define NINJA_HASH_LOG_H_
+
+#include <map>
+#include <vector>
+#include <string>
+
+#include <stdio.h>
+
+#ifdef _WIN32
+#include "win32port.h"
+#else
+#include <stdint.h>
+#endif
+
+#include "hash_map.h"
+#include "disk_interface.h"
+
+struct Node;
+struct Edge;
+struct State;
+
+#if defined(_MSC_VER) && (_MSC_VER < 1900)
+using stdext::hash_map;
+using stdext::hash_compare;
+
+struct StringPieceCmp : public hash_compare<StringPiece> {
+  size_t operator()(const StringPiece& key) const {
+    return MurmurHash2(key.str_, key.len_);
+  }
+  bool operator()(const StringPiece& a, const StringPiece& b) const {
+    int cmp = memcmp(a.str_, b.str_, min(a.len_, b.len_));
+    if (cmp < 0) {
+      return true;
+    } else if (cmp > 0) {
+      return false;
+    } else {
+      return a.len_ < b.len_;
+    }
+  }
+};
+
+#elif (__cplusplus < 201103L)
+namespace __gnu_cxx {
+template<>
+struct hash<Node*> {
+  size_t operator()(Node* key) const {
+    return hash<uintptr_t>()(reinterpret_cast<uintptr_t>(key));
+  }
+};
+}
+#endif
+
+struct HashLog {
+  typedef FileHasher::Hash Hash;
+
+  explicit HashLog(FileHasher *hasher);
+  ~HashLog();
+
+  bool Load(const string& path, State* state, string* err);
+
+  /// Check whether an edge's input and output hashes match previously
+  /// recorded values.  The stat information on the inputs and outputs
+  /// must be current for this to give the correct result.
+  bool HashesAreClean(Node *output, Edge* edge, string* err);
+
+  bool OpenForWrite(const string &path, string* err);
+  void Close();
+
+  /// Persist hashes (inputs and outputs) for a finished edge.
+  bool RecordHashes(Edge* edge, DiskInterface* disk_interface, string* err);
+
+  /// Recompact the hash log to reduce it to minimum size
+  bool Recompact(const string &path, string* err);
+
+  struct HashRecord {
+    /// The timestamp of the file when the hash was computed.  Hashes are only
+    /// recomputed if the timestamp is different.
+    TimeStamp mtime_;
+    /// The hash value.
+    Hash value_;
+
+    HashRecord() : mtime_(-1), value_(0) {}
+  };
+
+  /// For NinjaMain::ToolHashes and testing.
+
+  /// Retrieve the nodes for which there are hashes stored.
+  vector<Node*> GetOutputs() const;
+  /// Get the number of hashes known for a given output.
+  size_t GetInputCount(Node *node) const;
+  /// Get the hash of the input of the given output.
+  HashRecord *GetInputHash(Node *output, Node *input) const;
+
+ protected:
+  struct IdHashRecord : HashRecord {
+    /// Id of the node this hash is for.
+    int id_;
+
+    bool operator==(const IdHashRecord &other) const;
+    bool operator<(const IdHashRecord &other) const;
+    bool operator<(int id) const;
+
+    IdHashRecord() : id_(-1) {}
+  };
+
+  /// Records for the inputs of a node.
+  typedef vector<IdHashRecord> Inputs;
+
+  /// Record for a node.
+  /// If the node is seen as an input the HashRecord is populated.
+  /// If the node is seen as an output the inputs are populated.
+  struct NodeRecord : HashRecord {
+    Inputs inputs_;
+  };
+
+  /// Get the id for the node.  Returns -1 if the node is unknown.
+  int GetId(Node *node) const;
+  /// Get the id for the node, creating and recording a new one if the node is
+  /// unknown.  Returns -1 and sets err on error.
+  int GetOrCreateId(Node *node, string* err);
+
+  /// Get the record for the node.  Returns NULL if the node is unknown.
+  NodeRecord *GetRecord(Node *node) const;
+  NodeRecord *GetRecord(int id) const;
+  /// Get the record for the node with the given id.  Creates a new record if
+  /// one doesn't exist.
+  NodeRecord *GetOrCreateRecord(int id);
+
+  /// Compute the hash for the given node, using internal cache if available.
+  HashRecord *ComputeHash(Node *node, int id, string* err);
+
+  /// For testing.
+  HashRecord *GetHash(Node *node) const;
+
+  bool RecordHashes(Node *output, const Inputs& inputs, string* err);
+
+  IdHashRecord *GetInputHash(NodeRecord *record, Node *input) const;
+
+  /// Persist the id->path mapping.
+  bool WriteId(int id, Node *node, string* err);
+  /// Persist the record.
+  bool WriteEntry(int id, NodeRecord* record, string* err);
+
+  FILE* file_;
+
+  FileHasher *hasher_;
+
+#if (__cplusplus >= 201103L) || (_MSC_VER >= 1900)
+  typedef std::unordered_map<Node*, int> Ids;
+#else
+  typedef hash_map<Node*, int> Ids;
+#endif
+
+  /// Node to id mapping.
+  Ids ids_;
+  /// Records indexed by node id.
+  vector<NodeRecord*> hashes_;
+
+  bool needs_recompaction_;
+};
+
+#endif //NINJA_HASH_LOG_H_

--- a/src/hash_log_test.cc
+++ b/src/hash_log_test.cc
@@ -1,0 +1,505 @@
+// Copyright 2014 Matthias Maennich (matthias@maennich.net).
+//           2016 SAP SE
+// All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <sstream>
+#include <iostream>
+#include <algorithm>
+#include <set>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <time.h>
+#include <unistd.h>
+#endif
+
+#include "graph.h"
+#include "hash_log.h"
+#include "test.h"
+
+namespace {
+
+const char kTestFilename[] = "HashLogTest-tempfile";
+
+struct TestHashLog : HashLog {
+  explicit TestHashLog(FileHasher *hasher) : HashLog(hasher) {}
+  size_t GetOutputCount() const { return GetOutputs().size(); }
+
+  // Expose members needed for the tests.
+  using HashLog::GetHash;
+};
+
+typedef TestHashLog::HashRecord HashRecord;
+
+struct HashLogTest : public testing::Test {
+  typedef HashLog::Hash Hash;
+
+  HashLogTest() : log_(&disk_interface_) {}
+
+  void cleanup() {
+    unlink(kTestFilename);
+  }
+
+  virtual void SetUp() { cleanup(); };
+  virtual void TearDown() { cleanup(); };
+
+  VirtualFileSystem disk_interface_;
+  TestHashLog log_;
+  State state_;
+  string err;
+};
+
+TEST_F(HashLogTest, BasicInOut) {
+  // Create an edge with inputs and outputs.
+  Node *output = state_.GetNode("foo.o", 0);
+  Node *input1 = state_.GetNode("foo.cc", 0);
+  Node *input2 = state_.GetNode("foo.h", 0);
+  Node *input3 = state_.GetNode("bar.h", 0);
+  Edge edge;
+  edge.outputs_.push_back(output);
+  edge.inputs_.push_back(input1);
+  edge.inputs_.push_back(input2);
+  edge.inputs_.push_back(input3);
+
+  ASSERT_TRUE(disk_interface_.WriteFile(input1->path(), "void foo() {}"));
+  disk_interface_.Tick();
+  ASSERT_TRUE(disk_interface_.WriteFile(input2->path(), "void foo();"));
+  disk_interface_.Tick();
+  ASSERT_TRUE(disk_interface_.WriteFile(input3->path(), "void bar();"));
+
+  for (size_t i = 0; i < edge.inputs_.size(); ++i) {
+    ASSERT_TRUE(edge.inputs_[i]->Stat(&disk_interface_, &err));
+  }
+
+  ASSERT_TRUE(output->Stat(&disk_interface_, &err));
+
+  // Open the log.
+  ASSERT_TRUE(log_.OpenForWrite(kTestFilename, &err));
+  ASSERT_TRUE(err.empty());
+
+  // Hashes are dirty before the first build.
+  ASSERT_FALSE(log_.HashesAreClean(output, &edge, &err));
+  ASSERT_TRUE(err.empty());
+  ASSERT_EQ(0u, log_.GetOutputCount());
+
+  // No files have been read.
+  ASSERT_TRUE(disk_interface_.files_read_.empty());
+
+  // Record hashes.
+  ASSERT_TRUE(log_.RecordHashes(&edge, &disk_interface_, &err));
+  ASSERT_TRUE(err.empty());
+  ASSERT_EQ(1u, log_.GetOutputCount());
+
+  // Recording hashes should have read the three input files and nothing more.
+  {
+    const vector<string> &f = disk_interface_.files_read_;
+    ASSERT_EQ(1u, count(f.begin(), f.end(), input1->path()));
+    ASSERT_EQ(1u, count(f.begin(), f.end(), input2->path()));
+    ASSERT_EQ(1u, count(f.begin(), f.end(), input3->path()));
+    ASSERT_EQ(3u, f.size());
+  }
+
+  // The hash log should now contain entries for the inputs and the output.
+  ASSERT_EQ(3u, log_.GetInputCount(output));
+
+  for (size_t i = 0; i < edge.inputs_.size(); ++i) {
+    Node *node = edge.inputs_[i];
+    HashRecord *hash = log_.GetInputHash(output, node);
+    ASSERT_TRUE(hash);
+    ASSERT_EQ(node->mtime(), hash->mtime_);
+    ASSERT_NE(0u, hash->value_);
+  }
+
+  // Now the hashes should be clean.
+  ASSERT_TRUE(log_.HashesAreClean(output, &edge, &err));
+  ASSERT_TRUE(err.empty());
+
+  // Update the first and third input's timestamp.
+  disk_interface_.files_[input1->path()].mtime = disk_interface_.Tick();
+  ASSERT_TRUE(input1->Stat(&disk_interface_, &err));
+  ASSERT_TRUE(err.empty());
+  disk_interface_.files_[input3->path()].mtime = disk_interface_.Tick();
+  ASSERT_TRUE(input3->Stat(&disk_interface_, &err));
+  ASSERT_TRUE(err.empty());
+
+  disk_interface_.files_read_.clear();
+
+  // Now the hashes should still be clean.
+  ASSERT_TRUE(log_.HashesAreClean(output, &edge, &err));
+  ASSERT_TRUE(err.empty());
+
+  // This should have reread these two files.
+  {
+    const vector<string> &f = disk_interface_.files_read_;
+    ASSERT_EQ(1u, count(f.begin(), f.end(), input1->path()));
+    ASSERT_EQ(1u, count(f.begin(), f.end(), input3->path()));
+    ASSERT_EQ(2u, f.size());
+  }
+
+  // mtimes should now be current.
+  ASSERT_EQ(3u, log_.GetInputCount(output));
+
+  for (size_t i = 0; i < edge.inputs_.size(); ++i) {
+    Node *node = edge.inputs_[i];
+    HashRecord *hash = log_.GetInputHash(output, node);
+    ASSERT_TRUE(hash);
+    ASSERT_EQ(node->mtime(), hash->mtime_);
+    ASSERT_NE(0u, hash->value_);
+  }
+
+  disk_interface_.files_read_.clear();
+
+  // Yet another check will still succeed but won't read any files.
+  ASSERT_TRUE(log_.HashesAreClean(output, &edge, &err));
+  ASSERT_TRUE(err.empty());
+  ASSERT_TRUE(disk_interface_.files_read_.empty());
+}
+
+TEST_F(HashLogTest, WriteRead) {
+  // Create an edge with inputs and outputs.
+  Edge edge;
+  edge.outputs_.push_back(state_.GetNode("foo.o", 0));
+  edge.inputs_.push_back(state_.GetNode("foo.cc", 0));
+  edge.inputs_.push_back(state_.GetNode("foo.h", 0));
+  edge.inputs_.push_back(state_.GetNode("bar.h", 0));
+
+  ASSERT_TRUE(disk_interface_.WriteFile(edge.inputs_[0]->path(), "void foo() {}"));
+  disk_interface_.Tick();
+  ASSERT_TRUE(disk_interface_.WriteFile(edge.inputs_[1]->path(), "void foo();"));
+  disk_interface_.Tick();
+  ASSERT_TRUE(disk_interface_.WriteFile(edge.inputs_[2]->path(), "void bar();"));
+
+  // Open the log.
+  ASSERT_TRUE(log_.OpenForWrite(kTestFilename, &err));
+  ASSERT_TRUE(err.empty());
+
+  // Record hashes.
+  ASSERT_TRUE(log_.RecordHashes(&edge, &disk_interface_, &err));
+  ASSERT_TRUE(err.empty());
+  ASSERT_EQ(1u, log_.GetOutputCount());
+  ASSERT_EQ(3u, log_.GetInputCount(edge.outputs_[0]));
+
+  // Close old log object.
+  log_.Close();
+
+  // Open log in new object.
+  TestHashLog log2(&disk_interface_);
+
+  ASSERT_TRUE(log2.Load(kTestFilename, &state_, &err));
+  ASSERT_TRUE(err.empty());
+  ASSERT_EQ(1u, log2.GetOutputCount());
+  ASSERT_EQ(3u, log2.GetInputCount(edge.outputs_[0]));
+
+  // Files should still be known to be clean.
+  ASSERT_TRUE(log2.HashesAreClean(edge.outputs_[0], &edge, &err));
+  ASSERT_TRUE(err.empty());
+}
+
+TEST_F(HashLogTest, CheckOnlyFirst) {
+  // Create an edge with inputs and outputs.
+  Node *output = state_.GetNode("foo.o", 0);
+  Node *input1 = state_.GetNode("foo.cc", 0);
+  Node *input2 = state_.GetNode("foo.h", 0);
+  Node *input3 = state_.GetNode("bar.h", 0);
+  Edge edge;
+  edge.outputs_.push_back(output);
+  edge.inputs_.push_back(input1);
+  edge.inputs_.push_back(input2);
+  edge.inputs_.push_back(input3);
+
+  ASSERT_TRUE(disk_interface_.WriteFile(input1->path(), "void foo() {}"));
+  disk_interface_.Tick();
+  ASSERT_TRUE(disk_interface_.WriteFile(input2->path(), "void foo();"));
+  disk_interface_.Tick();
+  ASSERT_TRUE(disk_interface_.WriteFile(input3->path(), "void bar();"));
+
+  // Open the log.
+  ASSERT_TRUE(log_.OpenForWrite(kTestFilename, &err));
+  ASSERT_TRUE(err.empty());
+
+  // Record hashes.
+  ASSERT_TRUE(log_.RecordHashes(&edge, &disk_interface_, &err));
+  ASSERT_TRUE(err.empty());
+  ASSERT_EQ(1u, log_.GetOutputCount());
+  ASSERT_EQ(3u, log_.GetInputCount(output));
+
+  // Update the first and second input.
+  disk_interface_.Tick();
+  ASSERT_TRUE(disk_interface_.WriteFile(input1->path(), "void foo(int) {}"));
+  ASSERT_TRUE(input1->Stat(&disk_interface_, &err));
+  disk_interface_.Tick();
+  ASSERT_TRUE(disk_interface_.WriteFile(input2->path(), "void foo(int);"));
+  ASSERT_TRUE(input2->Stat(&disk_interface_, &err));
+
+  disk_interface_.files_read_.clear();
+
+  // Hashes are now dirty.
+  ASSERT_FALSE(log_.HashesAreClean(edge.outputs_[0], &edge, &err));
+  ASSERT_TRUE(err.empty());
+  ASSERT_EQ(1u, log_.GetOutputCount());
+  ASSERT_EQ(3u, log_.GetInputCount(output));
+
+  // Only the first input should have been read.
+  ASSERT_EQ(1u, disk_interface_.files_read_.size());
+  ASSERT_EQ(input1->path(), disk_interface_.files_read_[0]);
+
+  // The first inputs's mtime should be cached.
+  ASSERT_TRUE(log_.GetHash(input1))
+  ASSERT_EQ(input1->mtime(), log_.GetHash(input1)->mtime_);
+
+  // The second inputs's mtime should not be cached.
+  ASSERT_TRUE(log_.GetHash(input2))
+  ASSERT_NE(input2->mtime(), log_.GetHash(input2)->mtime_);
+
+  // However, the output should not be updated for neither.
+  ASSERT_TRUE(log_.GetInputHash(output, input1))
+  ASSERT_NE(input1->mtime(), log_.GetInputHash(output, input1)->mtime_)
+  ASSERT_TRUE(log_.GetInputHash(output, input2))
+  ASSERT_NE(input2->mtime(), log_.GetInputHash(output, input2)->mtime_)
+}
+
+TEST_F(HashLogTest, SameInputs) {
+  // Create an edge with inputs and outputs.
+  Edge edge;
+  edge.outputs_.push_back(state_.GetNode("foo.o", 0));
+  edge.inputs_.push_back(state_.GetNode("foo.cc", 0));
+  edge.inputs_.push_back(state_.GetNode("foo.h", 0));
+  edge.inputs_.push_back(state_.GetNode("bar.h", 0));
+
+  ASSERT_TRUE(disk_interface_.WriteFile(edge.inputs_[0]->path(), "void foo() {}"));
+  disk_interface_.Tick();
+  ASSERT_TRUE(disk_interface_.WriteFile(edge.inputs_[1]->path(), "void foo();"));
+  disk_interface_.Tick();
+  ASSERT_TRUE(disk_interface_.WriteFile(edge.inputs_[2]->path(), "void bar();"));
+
+  // Create a second edge with the same inputs but a different output.
+  Edge edge2;
+  edge2.outputs_.push_back(state_.GetNode("foo-debug.o", 0));
+  edge2.inputs_ = edge.inputs_;
+
+  // Open the log.
+  ASSERT_TRUE(log_.OpenForWrite(kTestFilename, &err));
+  ASSERT_TRUE(err.empty());
+
+  // Record hashes for the first edge.
+  ASSERT_TRUE(log_.RecordHashes(&edge, &disk_interface_, &err));
+  ASSERT_TRUE(err.empty());
+
+  // Hashes are clean for the first edge.
+  ASSERT_TRUE(log_.HashesAreClean(edge.outputs_[0], &edge, &err));
+  ASSERT_TRUE(err.empty());
+
+  // Hashes are still dirty for the second edge.
+  ASSERT_FALSE(log_.HashesAreClean(edge2.outputs_[0], &edge, &err));
+  ASSERT_TRUE(err.empty());
+
+  // Record hashes for the second edge.
+  ASSERT_TRUE(log_.RecordHashes(&edge2, &disk_interface_, &err));
+  ASSERT_TRUE(err.empty());
+
+  // Update an input's content.
+  disk_interface_.Tick();
+  ASSERT_TRUE(disk_interface_.WriteFile(edge.inputs_[2]->path(), "void bar(int);"));
+  ASSERT_TRUE(edge.inputs_[2]->Stat(&disk_interface_, &err));
+
+  // Hashes are dirty for both edges.
+  ASSERT_FALSE(log_.HashesAreClean(edge.outputs_[0], &edge, &err));
+  ASSERT_TRUE(err.empty());
+  ASSERT_FALSE(log_.HashesAreClean(edge2.outputs_[0], &edge, &err));
+  ASSERT_TRUE(err.empty());
+
+  // Record hashes for the first edge again.
+  ASSERT_TRUE(log_.RecordHashes(&edge, &disk_interface_, &err));
+  ASSERT_TRUE(err.empty());
+
+  // Hashes are still dirty for the second edge.
+  ASSERT_FALSE(log_.HashesAreClean(edge2.outputs_[0], &edge, &err));
+  ASSERT_TRUE(err.empty());
+}
+
+TEST_F(HashLogTest, RepeatedInput) {
+  // Create an edge with inputs and outputs.
+  Edge edge;
+  edge.outputs_.push_back(state_.GetNode("foo.o", 0));
+  edge.inputs_.push_back(state_.GetNode("foo.cc", 0));
+  edge.inputs_.push_back(state_.GetNode("foo.h", 0));
+  edge.inputs_.push_back(state_.GetNode("bar.h", 0));
+
+  ASSERT_TRUE(disk_interface_.WriteFile(edge.inputs_[0]->path(), "void foo() {}"));
+  disk_interface_.Tick();
+  ASSERT_TRUE(disk_interface_.WriteFile(edge.inputs_[1]->path(), "void foo();"));
+  disk_interface_.Tick();
+  ASSERT_TRUE(disk_interface_.WriteFile(edge.inputs_[2]->path(), "void bar();"));
+
+  // Append an input a second time.
+  edge.inputs_.push_back(state_.GetNode("bar.h", 0));
+
+  // Open the log and record hashes.
+  ASSERT_TRUE(log_.OpenForWrite(kTestFilename, &err));
+  ASSERT_TRUE(err.empty());
+  ASSERT_TRUE(log_.RecordHashes(&edge, &disk_interface_, &err));
+  ASSERT_TRUE(err.empty());
+
+  // Update the duplicated input's timestamp.
+  disk_interface_.files_[edge.inputs_[2]->path()].mtime = disk_interface_.Tick();
+  ASSERT_TRUE(edge.inputs_[2]->Stat(&disk_interface_, &err));
+  ASSERT_TRUE(err.empty());
+
+  disk_interface_.files_read_.clear();
+
+  // Hashes should still be clean but the file should be reread.
+  ASSERT_TRUE(log_.HashesAreClean(edge.outputs_[0], &edge, &err));
+  ASSERT_TRUE(err.empty());
+  ASSERT_EQ(1u, disk_interface_.files_read_.size());
+  ASSERT_EQ(edge.inputs_[2]->path(), disk_interface_.files_read_[0]);
+
+  // Update the duplicated input's content.
+  disk_interface_.Tick();
+  ASSERT_TRUE(disk_interface_.WriteFile(edge.inputs_[2]->path(), "void bar(int);"));
+
+  // Hashes should be dirty now.
+  ASSERT_TRUE(log_.HashesAreClean(edge.outputs_[0], &edge, &err));
+  ASSERT_TRUE(err.empty());
+  ASSERT_EQ(1u, disk_interface_.files_read_.size());
+  ASSERT_EQ(edge.inputs_[2]->path(), disk_interface_.files_read_[0]);
+}
+
+TEST_F(HashLogTest, NoInputs) {
+  // Create an edge without inputs.
+  Node *output = state_.GetNode("foo.o", 0);
+  Edge edge;
+  edge.outputs_.push_back(output);
+
+  // Open the log.
+  ASSERT_TRUE(log_.OpenForWrite(kTestFilename, &err));
+  ASSERT_TRUE(err.empty());
+
+  // Hashes are dirty since the node is unknown.
+  ASSERT_FALSE(log_.HashesAreClean(output, &edge, &err));
+  ASSERT_TRUE(err.empty());
+  ASSERT_EQ(0u, log_.GetOutputCount());
+
+  // Record hashes.
+  ASSERT_TRUE(log_.RecordHashes(&edge, &disk_interface_, &err));
+  ASSERT_TRUE(err.empty());
+
+  // Nothing is recorded.
+  ASSERT_EQ(0u, log_.GetOutputCount());
+
+  // Hashes are clean since the node is now known.
+  ASSERT_TRUE(log_.HashesAreClean(output, &edge, &err));
+  ASSERT_TRUE(err.empty());
+}
+
+TEST_F(HashLogTest, AddInput) {
+  // Create an edge with inputs and outputs.
+  Node *output = state_.GetNode("foo.o", 0);
+  Node *input1 = state_.GetNode("foo.cc", 0);
+  Node *input2 = state_.GetNode("foo.h", 0);
+  Node *input3 = state_.GetNode("bar.h", 0);
+  Edge edge;
+  edge.outputs_.push_back(output);
+  edge.inputs_.push_back(input1);
+  edge.inputs_.push_back(input2);
+
+  ASSERT_TRUE(disk_interface_.WriteFile(input1->path(), "void foo() {}"));
+  disk_interface_.Tick();
+  ASSERT_TRUE(disk_interface_.WriteFile(input2->path(), "void foo();"));
+  disk_interface_.Tick();
+  ASSERT_TRUE(disk_interface_.WriteFile(input3->path(), "void bar();"));
+
+  // Open the log.
+  ASSERT_TRUE(log_.OpenForWrite(kTestFilename, &err));
+  ASSERT_TRUE(err.empty());
+
+  // Record hashes.
+  ASSERT_TRUE(log_.RecordHashes(&edge, &disk_interface_, &err));
+  ASSERT_TRUE(err.empty());
+  ASSERT_EQ(1u, log_.GetOutputCount());
+  ASSERT_EQ(2u, log_.GetInputCount(output));
+
+  // Hashes are clean.
+  ASSERT_TRUE(log_.HashesAreClean(output, &edge, &err));
+  ASSERT_TRUE(err.empty());
+
+  // Add a new input.
+  edge.inputs_.push_back(input3);
+
+  // Hashes are dirty now.
+  ASSERT_FALSE(log_.HashesAreClean(output, &edge, &err));
+  ASSERT_TRUE(err.empty());
+
+  // Record new hashes.
+  ASSERT_TRUE(log_.RecordHashes(&edge, &disk_interface_, &err));
+  ASSERT_TRUE(err.empty());
+  ASSERT_EQ(1u, log_.GetOutputCount());
+  ASSERT_EQ(3u, log_.GetInputCount(output));
+}
+
+TEST_F(HashLogTest, RemoveInput) {
+  // Create an edge with inputs and outputs.
+  Node *output = state_.GetNode("foo.o", 0);
+  Node *input1 = state_.GetNode("foo.cc", 0);
+  Node *input2 = state_.GetNode("foo.h", 0);
+  Node *input3 = state_.GetNode("bar.h", 0);
+  Edge edge;
+  edge.outputs_.push_back(output);
+  edge.inputs_.push_back(input1);
+  edge.inputs_.push_back(input2);
+  edge.inputs_.push_back(input3);
+
+  ASSERT_TRUE(disk_interface_.WriteFile(input1->path(), "void foo() {}"));
+  disk_interface_.Tick();
+  ASSERT_TRUE(disk_interface_.WriteFile(input2->path(), "void foo();"));
+  disk_interface_.Tick();
+  ASSERT_TRUE(disk_interface_.WriteFile(input3->path(), "void bar();"));
+
+  // Open the log.
+  ASSERT_TRUE(log_.OpenForWrite(kTestFilename, &err));
+  ASSERT_TRUE(err.empty());
+
+  // Record hashes.
+  ASSERT_TRUE(log_.RecordHashes(&edge, &disk_interface_, &err));
+  ASSERT_TRUE(err.empty());
+  ASSERT_EQ(1u, log_.GetOutputCount());
+  ASSERT_EQ(3u, log_.GetInputCount(output));
+
+  // Hashes are clean.
+  ASSERT_TRUE(log_.HashesAreClean(output, &edge, &err));
+  ASSERT_TRUE(err.empty());
+
+  // Remove second input.
+  edge.inputs_.erase(edge.inputs_.begin() + 1);
+
+  // Hashes are clean, since we do not care about removed inputs.
+  ASSERT_TRUE(log_.HashesAreClean(output, &edge, &err));
+  ASSERT_TRUE(err.empty());
+
+  // Record new hashes.
+  ASSERT_TRUE(log_.RecordHashes(&edge, &disk_interface_, &err));
+  ASSERT_TRUE(err.empty());
+  ASSERT_EQ(1u, log_.GetOutputCount());
+  ASSERT_EQ(2u, log_.GetInputCount(output));
+}
+
+// test to be done:
+// * error paths: missing output, missing inputs etc.
+// * recompacting
+// * rerecording the same hash should not increase the log size
+// * check hashes without opening for write
+
+}  // anonymous namespace

--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -172,6 +172,11 @@ bool ManifestParser::ParseRule(string* err) {
 
     if (Rule::IsReservedBinding(key)) {
       rule->AddBinding(key, value);
+      // Set flag so the builder can skip opening the hash log if it isn't
+      // needed.
+      if (!state_->need_hash_log_ && key == "hash_input" && !value.empty()) {
+        state_->need_hash_log_ = true;
+      }
     } else {
       // Die on other keyvals for now; revisit if we want to add a
       // scope here.

--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -67,6 +67,7 @@ TEST_F(ParserTest, RuleAttributes) {
 "  restat = a\n"
 "  rspfile = a\n"
 "  rspfile_content = a\n"
+"  hash_input = a\n"
 ));
 }
 

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -34,6 +34,7 @@
 #include "build.h"
 #include "build_log.h"
 #include "deps_log.h"
+#include "hash_log.h"
 #include "clean.h"
 #include "debug_flags.h"
 #include "disk_interface.h"
@@ -76,7 +77,8 @@ struct Options {
 /// to poke into these, so store them as fields on an object.
 struct NinjaMain : public BuildLogUser {
   NinjaMain(const char* ninja_command, const BuildConfig& config) :
-      ninja_command_(ninja_command), config_(config) {}
+      ninja_command_(ninja_command), config_(config), disk_interface_(),
+      hash_log_(&disk_interface_) {}
 
   /// Command line used to run Ninja.
   const char* ninja_command_;
@@ -95,6 +97,7 @@ struct NinjaMain : public BuildLogUser {
 
   BuildLog build_log_;
   DepsLog deps_log_;
+  HashLog hash_log_;
 
   /// The type of functions that are the entry points to tools (subcommands).
   typedef int (NinjaMain::*ToolFunc)(int, char**);
@@ -111,6 +114,7 @@ struct NinjaMain : public BuildLogUser {
   int ToolGraph(int argc, char* argv[]);
   int ToolQuery(int argc, char* argv[]);
   int ToolDeps(int argc, char* argv[]);
+  int ToolHashes(int argc, char* argv[]);
   int ToolBrowse(int argc, char* argv[]);
   int ToolMSVC(int argc, char* argv[]);
   int ToolTargets(int argc, char* argv[]);
@@ -127,6 +131,10 @@ struct NinjaMain : public BuildLogUser {
   /// Open the deps log: load it, then open for writing.
   /// @return false on error.
   bool OpenDepsLog(bool recompact_only = false);
+
+  /// Open the hash log: load it, then open for writing.
+  /// @return false on error.
+  bool OpenHashLog(bool recompact_only = false);
 
   /// Ensure the build directory exists, creating it if necessary.
   /// @return false on error.
@@ -240,7 +248,9 @@ bool NinjaMain::RebuildManifest(const char* input_file, string* err) {
   if (!node)
     return false;
 
-  Builder builder(&state_, config_, &build_log_, &deps_log_, &disk_interface_);
+  Builder builder(&state_, config_, &build_log_, &deps_log_,
+                  state_.need_hash_log_ ? &hash_log_ : NULL,
+                  &disk_interface_);
   if (!builder.AddTarget(node, err))
     return false;
 
@@ -497,6 +507,85 @@ int NinjaMain::ToolDeps(int argc, char** argv) {
   return 0;
 }
 
+int NinjaMain::ToolHashes(int argc, char** argv) {
+  if (!state_.need_hash_log_) {
+    printf("hash log not enabled\n");
+    return 0;
+  }
+
+  string err;
+  vector<Node*> nodes;
+  if (argc == 0) {
+    nodes = hash_log_.GetOutputs();
+  } else {
+    if (!CollectTargetsFromArgs(argc, argv, &nodes, &err)) {
+      Error("%s", err.c_str());
+      return 1;
+    }
+  }
+
+  ImplicitDepLoader dep_loader(&state_, &deps_log_, &disk_interface_);
+
+  for (vector<Node*>::iterator i = nodes.begin(), end = nodes.end();
+       i != end; ++i) {
+    Edge *edge = (*i)->in_edge();
+
+    // In order to report on the hashes of the deps they need to be loaded.
+    if (!dep_loader.LoadDeps(edge, &err)) {
+      if (!err.empty())
+        Error("%s", err.c_str());
+      printf("%s: deps not found\n", (*i)->path().c_str());
+      continue;
+    }
+
+    printf("%s: #hashes %u\n", (*i)->path().c_str(), (unsigned)hash_log_.GetInputCount(*i));
+
+    bool is_clean = true;
+
+    for (vector<Node*>::const_iterator j = edge->inputs_.begin();
+        j != edge->inputs_.end() - edge->order_only_deps_; ++j) {
+      printf("    %s ", (*j)->path().c_str());
+
+      HashLog::HashRecord *hash = hash_log_.GetInputHash(*i, *j);
+
+      if (!hash) {
+        printf("UNKNOWN\n");
+        is_clean = false;
+        continue;
+      }
+
+      TimeStamp mtime = disk_interface_.Stat((*j)->path(), &err);
+      if (mtime == -1) {
+        printf("ERROR: %s\n", err.c_str());
+        is_clean = false;
+        continue;
+      }
+
+      DiskInterface::Hash hash_value;
+
+      if (disk_interface_.HashFile((*j)->path(), &hash_value, &err) == DiskInterface::OtherError) {
+        printf("ERROR: %s\n", err.c_str());
+        is_clean = false;
+        continue;
+      }
+
+      printf("hash mtime %d (%s), hash value %08x (%s)\n",
+             hash->mtime_,
+             mtime == 0 ? "MISSING" :
+             mtime > hash->mtime_ ? "STALE" : "VALID",
+             hash->value_,
+             hash_value == hash->value_ ? "CLEAN" : "DIRTY");
+    }
+
+    if (is_clean)
+      printf("    CLEAN\n");
+    else
+      printf("    DIRTY\n");
+  }
+
+  return 0;
+}
+
 int NinjaMain::ToolTargets(int argc, char* argv[]) {
   int depth = 1;
   if (argc >= 1) {
@@ -668,8 +757,11 @@ int NinjaMain::ToolRecompact(int argc, char* argv[]) {
   if (!EnsureBuildDirExists())
     return 1;
 
+  string err;
+
   if (!OpenBuildLog(/*recompact_only=*/true) ||
-      !OpenDepsLog(/*recompact_only=*/true))
+      !OpenDepsLog(/*recompact_only=*/true)  ||
+      !OpenHashLog(/*recompact_only=*/true))
     return 1;
 
   return 0;
@@ -719,6 +811,8 @@ const Tool* ChooseTool(const string& tool_name) {
       Tool::RUN_AFTER_LOAD, &NinjaMain::ToolCommands },
     { "deps", "show dependencies stored in the deps log",
       Tool::RUN_AFTER_LOGS, &NinjaMain::ToolDeps },
+    { "hashes", "show hashes stored in the hash log",
+      Tool::RUN_AFTER_LOGS, &NinjaMain::ToolHashes },
     { "graph", "output graphviz dot file for targets",
       Tool::RUN_AFTER_LOAD, &NinjaMain::ToolGraph },
     { "query", "show inputs/outputs for a path",
@@ -899,6 +993,39 @@ bool NinjaMain::OpenDepsLog(bool recompact_only) {
   return true;
 }
 
+bool NinjaMain::OpenHashLog(bool recompact_only) {
+  string path = ".ninja_hashes";
+  if (!build_dir_.empty())
+    path = build_dir_ + "/" + path;
+
+  string err;
+  if (!hash_log_.Load(path, &state_, &err)) {
+    Error("loading hash log %s: %s", path.c_str(), err.c_str());
+    return false;
+  }
+  if (!err.empty()) {
+    // Hack: Load() can return a warning via err by returning true.
+    Warning("%s", err.c_str());
+    err.clear();
+  }
+
+  if (recompact_only) {
+    bool success = hash_log_.Recompact(path, &err);
+    if (!success)
+      Error("failed recompaction: %s", err.c_str());
+    return success;
+  }
+
+  if (!config_.dry_run) {
+    if (!hash_log_.OpenForWrite(path, &err)) {
+      Error("opening hash log: %s", err.c_str());
+      return false;
+    }
+  }
+
+  return true;
+}
+
 void NinjaMain::DumpMetrics() {
   g_metrics->Report();
 
@@ -931,7 +1058,9 @@ int NinjaMain::RunBuild(int argc, char** argv) {
 
   disk_interface_.AllowStatCache(g_experimental_statcache);
 
-  Builder builder(&state_, config_, &build_log_, &deps_log_, &disk_interface_);
+  Builder builder(&state_, config_, &build_log_, &deps_log_,
+                  state_.need_hash_log_ ? &hash_log_ : NULL,
+                  &disk_interface_);
   for (size_t i = 0; i < targets.size(); ++i) {
     if (!builder.AddTarget(targets[i], &err)) {
       if (!err.empty()) {
@@ -1126,6 +1255,9 @@ int real_main(int argc, char** argv) {
       return 1;
 
     if (!ninja.OpenBuildLog() || !ninja.OpenDepsLog())
+      return 1;
+
+    if (ninja.state_.need_hash_log_ && !ninja.OpenHashLog())
       return 1;
 
     if (options.tool && options.tool->when == Tool::RUN_AFTER_LOGS)

--- a/src/state.cc
+++ b/src/state.cc
@@ -73,7 +73,7 @@ Pool State::kDefaultPool("", 0);
 Pool State::kConsolePool("console", 1);
 const Rule State::kPhonyRule("phony");
 
-State::State() {
+State::State() : need_hash_log_(false) {
   bindings_.AddRule(&kPhonyRule);
   AddPool(&kDefaultPool);
   AddPool(&kConsolePool);

--- a/src/state.h
+++ b/src/state.h
@@ -125,6 +125,9 @@ struct State {
 
   BindingEnv bindings_;
   vector<Node*> defaults_;
+
+  /// Seen a |hash_input| rule.  Builder might need the HashLog.
+  bool need_hash_log_;
 };
 
 #endif  // NINJA_STATE_H_

--- a/src/test.cc
+++ b/src/test.cc
@@ -31,6 +31,7 @@
 #include "graph.h"
 #include "manifest_parser.h"
 #include "util.h"
+#include "PMurHash.h"
 
 namespace {
 
@@ -189,6 +190,21 @@ int VirtualFileSystem::RemoveFile(const string& path) {
   } else {
     return 1;
   }
+}
+
+FileReader::Status VirtualFileSystem::HashFile(const string& path,
+                                               Hash* hash,
+                                               string* err) {
+  files_read_.push_back(path);
+  FileMap::iterator i = files_.find(path);
+  if (i != files_.end()) {
+    *hash = PMurHash32(0,
+                       i->second.contents.data(),
+                       i->second.contents.size());
+    return Okay;
+  }
+  *err = strerror(ENOENT);
+  return NotFound;
 }
 
 void ScopedTempDir::CreateAndEnter(const string& name) {

--- a/src/test.h
+++ b/src/test.h
@@ -147,6 +147,7 @@ struct VirtualFileSystem : public DiskInterface {
   virtual bool MakeDir(const string& path);
   virtual Status ReadFile(const string& path, string* contents, string* err);
   virtual int RemoveFile(const string& path);
+  virtual Status HashFile(const string& path, Hash* contents, string* err);
 
   /// An entry for a single in-memory file.
   struct Entry {


### PR DESCRIPTION
When a rule specifies "hash_input = 1" in addition to the modification
time of its inputs the hashed content of the inputs are taken into
account.  Hence a target is only dirty if the incoming edges are dirty
content-wise.

The purpose of the change is addressing workflows where input files are
rewritten but their content remains the same such.  This frequently
happens when working with version control systems, for example when
rebasing or switching branches.

For every completed edge the filenames of the outputs and filenames,
mtimes and 32bit Murmur3 hashes for the inputs are stored.

The mtime of a hashed files are stored to so that subsequent checks of
touched but clean files can compare that instead of recomputing the
hash.

The performance impact of the feature when it is disabled is negligible.
When it is enabled rereading the files and computing the hashes mostly
unnoticable - especially when the commands themselves are relatively
expensive, such as compiling C++ source files.

Co-Authored-By: Frank Benkstein frank.benkstein@sap.com
